### PR TITLE
PRO-1111: Inconsistent Results

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@etherspot/react-transaction-buidler",
-  "version": "0.23.12",
+  "version": "0.24.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@etherspot/react-transaction-buidler",
-      "version": "0.23.12",
+      "version": "0.24.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@etherspot/react-transaction-buidler",
-  "version": "0.23.12",
+  "version": "0.24.0",
   "description": "Etherspot React component.",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/src/components/TransactionBlock/AssetBridgeTransactionBlock.tsx
+++ b/src/components/TransactionBlock/AssetBridgeTransactionBlock.tsx
@@ -113,7 +113,7 @@ const AssetBridgeTransactionBlock = ({
 
   useEffect(() => {
     updateWalletBalances();
-  }, []);
+  }, [sdk, accountAddress]);
 
   useEffect(() => {
     const preselectAsset = async (multiCallData: IMultiCallData) => {

--- a/src/components/TransactionBlock/AssetBridgeTransactionBlock.tsx
+++ b/src/components/TransactionBlock/AssetBridgeTransactionBlock.tsx
@@ -72,6 +72,7 @@ const AssetBridgeTransactionBlock = ({
     accountAddress,
     getSupportedAssetsWithBalancesForChainId,
     smartWalletOnly,
+    handleGetBalances
   } = useEtherspot();
 
   const [amount, setAmount] = useState<string>(values?.amount ?? '');
@@ -107,6 +108,10 @@ const AssetBridgeTransactionBlock = ({
   } = useTransactionBuilder();
 
   const theme: Theme = useTheme()
+
+  useEffect(() => {
+    handleGetBalances();
+  }, []);
 
   useEffect(() => {
     const preselectAsset = async (multiCallData: IMultiCallData) => {

--- a/src/components/TransactionBlock/AssetSwapTransactionBlock.tsx
+++ b/src/components/TransactionBlock/AssetSwapTransactionBlock.tsx
@@ -154,7 +154,7 @@ const AssetSwapTransactionBlock = ({
 
   useEffect(() => {
     updateWalletBalances();
-  }, []);
+  }, [sdk, accountAddress]);
 
   useEffect(() => {
     // this will ensure that the old data won't replace the new one

--- a/src/components/TransactionBlock/AssetSwapTransactionBlock.tsx
+++ b/src/components/TransactionBlock/AssetSwapTransactionBlock.tsx
@@ -159,13 +159,21 @@ const AssetSwapTransactionBlock = ({
   useEffect(() => {
     // this will ensure that the old data won't replace the new one
     let active = true;
-    updateAvailableOffers().then((offers) => {
-      if (active && offers) {
+
+    const updateOffers = async () => {
+      try {
+        const offers = await updateAvailableOffers();
+        if (!active || !offers) return;
+
         setAvailableOffers(offers);
         if (offers.length === 1) setSelectedOffer(mapOfferToOption(offers[0]));
         setIsLoadingAvailableOffers(false);
+      } catch (e) {
+        //
       }
-    });
+    };
+
+    updateOffers();
 
     // hook's clean-up function
     return () => {

--- a/src/components/TransactionBlock/AssetSwapTransactionBlock.tsx
+++ b/src/components/TransactionBlock/AssetSwapTransactionBlock.tsx
@@ -92,6 +92,7 @@ const AssetSwapTransactionBlock = ({
     accountAddress,
     providerAddress,
     smartWalletOnly,
+    handleGetBalances
   } = useEtherspot();
   const theme: Theme = useTheme();
 
@@ -149,6 +150,10 @@ const AssetSwapTransactionBlock = ({
     }, 200),
     [sdk, selectedFromAsset, selectedToAsset, amount, selectedNetwork, accountAddress],
   );
+
+  useEffect(() => {
+    handleGetBalances();
+  }, []);
 
   useEffect(() => {
     // this will ensure that the old data won't replace the new one

--- a/src/components/TransactionBlock/AssetSwapTransactionBlock.tsx
+++ b/src/components/TransactionBlock/AssetSwapTransactionBlock.tsx
@@ -116,9 +116,8 @@ const AssetSwapTransactionBlock = ({
   const updateAvailableOffers = useCallback<() => Promise<ExchangeOffer[] | undefined>>(
     debounce(async () => {
       // there is a race condition here
-      if (multiCallData && fixed) {
-        return;
-      }
+      if (multiCallData && fixed) return;
+
       setSelectedOffer(null);
       setAvailableOffers([]);
 

--- a/src/components/TransactionBlock/SendAssetTransactionBlock.tsx
+++ b/src/components/TransactionBlock/SendAssetTransactionBlock.tsx
@@ -53,6 +53,7 @@ const SendAssetTransactionBlock = ({
   const { setTransactionBlockValues, resetTransactionBlockFieldValidationError } = useTransactionBuilder();
 
   const {
+    sdk,
     providerAddress,
     accountAddress,
     chainId,
@@ -78,7 +79,7 @@ const SendAssetTransactionBlock = ({
 
   useEffect(() => {
     updateWalletBalances();
-  }, []);
+  }, [sdk, accountAddress]);
 
   useEffect(() => {
     const preselectAsset = async (multiCallData: IMultiCallData) => {

--- a/src/components/TransactionBlock/SendAssetTransactionBlock.tsx
+++ b/src/components/TransactionBlock/SendAssetTransactionBlock.tsx
@@ -52,8 +52,14 @@ const SendAssetTransactionBlock = ({
   const theme: Theme = useTheme();
   const { setTransactionBlockValues, resetTransactionBlockFieldValidationError } = useTransactionBuilder();
 
-  const { providerAddress, accountAddress, chainId, getSupportedAssetsWithBalancesForChainId, smartWalletOnly } =
-    useEtherspot();
+  const {
+    providerAddress,
+    accountAddress,
+    chainId,
+    getSupportedAssetsWithBalancesForChainId,
+    smartWalletOnly,
+    handleGetBalances,
+  } = useEtherspot();
 
   const onAmountChange = useCallback(
     (newAmount: string) => {
@@ -68,6 +74,10 @@ const SendAssetTransactionBlock = ({
   const onReceiverAddressChange = useCallback((newReceiverAddress: string) => {
     resetTransactionBlockFieldValidationError(transactionBlockId, 'receiverAddress');
     setReceiverAddress(newReceiverAddress);
+  }, []);
+
+  useEffect(() => {
+    handleGetBalances();
   }, []);
 
   useEffect(() => {

--- a/src/components/TransactionBlock/SendAssetTransactionBlock.tsx
+++ b/src/components/TransactionBlock/SendAssetTransactionBlock.tsx
@@ -58,7 +58,7 @@ const SendAssetTransactionBlock = ({
     chainId,
     getSupportedAssetsWithBalancesForChainId,
     smartWalletOnly,
-    handleGetBalances,
+    updateWalletBalances,
   } = useEtherspot();
 
   const onAmountChange = useCallback(
@@ -77,7 +77,7 @@ const SendAssetTransactionBlock = ({
   }, []);
 
   useEffect(() => {
-    handleGetBalances();
+    updateWalletBalances();
   }, []);
 
   useEffect(() => {

--- a/src/components/TransactionBlock/Wallet/WalletTransactionBlock.tsx
+++ b/src/components/TransactionBlock/Wallet/WalletTransactionBlock.tsx
@@ -64,14 +64,8 @@ const WalletTransactionBlock = ({
 
   const theme: Theme = useTheme();
 
-  const {
-    providerAddress,
-    accountAddress,
-    getSupportedAssetsWithBalancesForChainId,
-    getNftsForChainId,
-    smartWalletBalanceByChain,
-    sdk,
-  } = useEtherspot();
+  const { providerAddress, accountAddress, getSupportedAssetsWithBalancesForChainId, getNftsForChainId, sdk } =
+    useEtherspot();
 
   const [tab, setTab] = useState<ITabs>('tokens');
   const [fetchingAssets, setFetchingAssets] = useState(false);
@@ -126,7 +120,6 @@ const WalletTransactionBlock = ({
   const getNfts = async () => {
     if (fetchingNfts) return;
     setFetchingNfts(true);
-    console.log('getting nfts');
 
     let allNfts: IChainNfts[] = [];
     supportedChains.map(async (chain, i) => {
@@ -187,7 +180,7 @@ const WalletTransactionBlock = ({
     if (!accountAddress || !sdk) return;
 
     getAssets();
-  }, [accountAddress, smartWalletBalanceByChain]);
+  }, [accountAddress]);
 
   useEffect(() => {
     if (tab !== 'nfts' || !!chainNfts) return;

--- a/src/components/TransactionBlock/Wallet/WalletTransactionBlock.tsx
+++ b/src/components/TransactionBlock/Wallet/WalletTransactionBlock.tsx
@@ -64,8 +64,14 @@ const WalletTransactionBlock = ({
 
   const theme: Theme = useTheme();
 
-  const { providerAddress, accountAddress, getSupportedAssetsWithBalancesForChainId, getNftsForChainId, sdk } =
-    useEtherspot();
+  const {
+    sdk,
+    providerAddress,
+    accountAddress,
+    getAssetsBalancesForChainId,
+    getSupportedAssetsWithBalancesForChainId,
+    getNftsForChainId,
+  } = useEtherspot();
 
   const [tab, setTab] = useState<ITabs>('tokens');
   const [fetchingAssets, setFetchingAssets] = useState(false);

--- a/src/containers/Etherspot.tsx
+++ b/src/containers/Etherspot.tsx
@@ -63,7 +63,7 @@ const Etherspot = ({
   etherspotSessionStorage,
   showMenuLogout,
   smartWalletOnly,
-  hideWalletBlock,
+  hideWalletBlock = false,
   onLogout,
 }: EtherspotProps) => (
   <ThemeProvider theme={merge({}, darkTheme, themeOverride)}>

--- a/src/containers/Etherspot.tsx
+++ b/src/containers/Etherspot.tsx
@@ -24,6 +24,7 @@ interface EtherspotProps {
   onLogout?: () => void;
   showMenuLogout?: boolean;
   smartWalletOnly?: boolean;
+  hideWalletBlock?: boolean;
 }
 
 const ComponentWrapper = styled.div`
@@ -62,6 +63,7 @@ const Etherspot = ({
   etherspotSessionStorage,
   showMenuLogout,
   smartWalletOnly,
+  hideWalletBlock,
   onLogout,
 }: EtherspotProps) => (
   <ThemeProvider theme={merge({}, darkTheme, themeOverride)}>
@@ -85,6 +87,7 @@ const Etherspot = ({
               hiddenTransactionBlockTypes={hiddenTransactionBlockTypes}
               hideAddTransactionButton={hideAddTransactionButton}
               showMenuLogout={showMenuLogout}
+              hideWalletBlock={hideWalletBlock}
             />
           </TransactionsDispatcherContextProvider>
         </TransactionBuilderModalContextProvider>

--- a/src/contexts/EtherspotContext.tsx
+++ b/src/contexts/EtherspotContext.tsx
@@ -46,6 +46,7 @@ export interface EtherspotContextData {
     setSmartWalletBalanceByChain: React.Dispatch<React.SetStateAction<IBalanceByChain[]>>;
     setKeybasedWalletBalanceByChain: React.Dispatch<React.SetStateAction<IBalanceByChain[]>>;
     getGasAssetsForChainId: (chainId: number, sender?: string) => Promise<IAssetWithBalance[]>;
+    handleGetBalances: (force?: boolean) => void;
   };
 }
 

--- a/src/contexts/EtherspotContext.tsx
+++ b/src/contexts/EtherspotContext.tsx
@@ -46,7 +46,7 @@ export interface EtherspotContextData {
     setSmartWalletBalanceByChain: React.Dispatch<React.SetStateAction<IBalanceByChain[]>>;
     setKeybasedWalletBalanceByChain: React.Dispatch<React.SetStateAction<IBalanceByChain[]>>;
     getGasAssetsForChainId: (chainId: number, sender?: string) => Promise<IAssetWithBalance[]>;
-    handleGetBalances: (force?: boolean) => void;
+    updateWalletBalances: (force?: boolean) => void;
   };
 }
 

--- a/src/providers/EtherspotContextProvider.tsx
+++ b/src/providers/EtherspotContextProvider.tsx
@@ -533,7 +533,7 @@ const EtherspotContextProvider = ({
     if (onLogout) onLogout();
   }, [setProvider, setProviderAddress, setAccountAddress, onLogout]);
 
-  const handleGetBalances = useCallback(
+  const updateWalletBalances = useCallback(
     async (force?: boolean) => {
       if (!sdk || !accountAddress) return;
 
@@ -574,7 +574,7 @@ const EtherspotContextProvider = ({
       setKeybasedWalletBalanceByChain,
       getKeybasedWalletBalancesPerChain,
       getGasAssetsForChainId,
-      handleGetBalances,
+      updateWalletBalances,
     }),
     [
       connect,
@@ -601,7 +601,7 @@ const EtherspotContextProvider = ({
       setKeybasedWalletBalanceByChain,
       getKeybasedWalletBalancesPerChain,
       getGasAssetsForChainId,
-      handleGetBalances,
+      updateWalletBalances,
     ]
   );
 

--- a/src/providers/EtherspotContextProvider.tsx
+++ b/src/providers/EtherspotContextProvider.tsx
@@ -537,13 +537,15 @@ const EtherspotContextProvider = ({
     async (force?: boolean) => {
       if (!sdk || !accountAddress) return;
 
-      if (!!force || !smartWalletBalanceByChain.length)
+      if (!!force || !smartWalletBalanceByChain.length) {
         await getSmartWalletBalancesByChain(accountAddress, supportedChains);
+      }
 
       if (!providerAddress) return;
 
-      if (!!force || !keybasedWalletBalanceByChain.length)
+      if (!!force || !keybasedWalletBalanceByChain.length) {
         await getKeybasedWalletBalancesPerChain(providerAddress, supportedChains);
+      }
     },
     [sdk, accountAddress, providerAddress, smartWalletBalanceByChain, keybasedWalletBalanceByChain]
   );

--- a/src/providers/TransactionBuilderContextProvider.tsx
+++ b/src/providers/TransactionBuilderContextProvider.tsx
@@ -278,7 +278,7 @@ const TransactionBuilderContextProvider = ({
   const mappedDefaultTransactionBlocks = defaultTransactionBlocks
     ? defaultTransactionBlocks.map(addIdToDefaultTransactionBlock)
     : [];
-  const [transactionBlocks, setTransactionBlocks] = useState<ITransactionBlock[]>([]);
+  const [transactionBlocks, setTransactionBlocks] = useState<ITransactionBlock[]>([...mappedDefaultTransactionBlocks]);
 
   type IValidationErrors = {
     [id: string]: ErrorMessages;
@@ -295,7 +295,7 @@ const TransactionBuilderContextProvider = ({
 
   const [copiedAddress, setCopiedAddress] = useState(false);
   const [copiedAddressInterval, setCopiedAddressInterval] = useState<number | null>(null);
-  const [showWalletBlock, setShowWalletBlock] = useState(true);
+  const [showWalletBlock, setShowWalletBlock] = useState(!mappedDefaultTransactionBlocks?.length);
 
   const theme: Theme = useTheme();
 

--- a/src/providers/TransactionBuilderContextProvider.tsx
+++ b/src/providers/TransactionBuilderContextProvider.tsx
@@ -271,7 +271,7 @@ const TransactionBuilderContextProvider = ({
   hiddenTransactionBlockTypes,
   hideAddTransactionButton,
   showMenuLogout,
-  hideWalletBlock,
+  hideWalletBlock = false,
 }: TransactionBuilderContextProps) => {
   const context = useContext(TransactionBuilderContext);
 
@@ -298,7 +298,7 @@ const TransactionBuilderContextProvider = ({
   const [copiedAddress, setCopiedAddress] = useState(false);
   const [copiedAddressInterval, setCopiedAddressInterval] = useState<number | null>(null);
 
-  const defaultShowWallet = !mappedDefaultTransactionBlocks?.length && (hideWalletBlock ?? true);
+  const defaultShowWallet = !mappedDefaultTransactionBlocks?.length && !hideWalletBlock;
   const [showWalletBlock, setShowWalletBlock] = useState(defaultShowWallet);
 
   const theme: Theme = useTheme();

--- a/src/providers/TransactionBuilderContextProvider.tsx
+++ b/src/providers/TransactionBuilderContextProvider.tsx
@@ -61,6 +61,7 @@ export interface TransactionBuilderContextProps {
   hiddenTransactionBlockTypes?: ITransactionBlockType[];
   hideAddTransactionButton?: boolean;
   showMenuLogout?: boolean;
+  hideWalletBlock?: boolean;
 }
 
 export interface IMulticallBlock {
@@ -270,6 +271,7 @@ const TransactionBuilderContextProvider = ({
   hiddenTransactionBlockTypes,
   hideAddTransactionButton,
   showMenuLogout,
+  hideWalletBlock,
 }: TransactionBuilderContextProps) => {
   const context = useContext(TransactionBuilderContext);
 
@@ -295,7 +297,9 @@ const TransactionBuilderContextProvider = ({
 
   const [copiedAddress, setCopiedAddress] = useState(false);
   const [copiedAddressInterval, setCopiedAddressInterval] = useState<number | null>(null);
-  const [showWalletBlock, setShowWalletBlock] = useState(!mappedDefaultTransactionBlocks?.length);
+
+  const defaultShowWallet = !mappedDefaultTransactionBlocks?.length && (hideWalletBlock ?? true);
+  const [showWalletBlock, setShowWalletBlock] = useState(defaultShowWallet);
 
   const theme: Theme = useTheme();
 


### PR DESCRIPTION
https://linear.app/pillarproject/issue/PRO-1111/etherspot-services-inconsistent-results

## Description
We were hitting the rates limiter very consistently on reloads, so the assets on the wallet block were loading inconsistently.

Fixes:
- We were using `getExchangeSupportedAssets` to get tokens, but were limited to getting 100 tokens per call, meaning we had to make a minimum of 30 calls just to get supported tokens. Changed this to `getTokenListTokens` which gets you all of them at once - but requires us to instantiate all of the sdks for each network.
- Removed a couple of useEffects getting balances to get wallet totals, and absorbed functionality into a new function, which runs when the relevant tx block is selected. As far as I can see everything still seems to work fine.
- The dApp seemed to get instantiated twice because of React.StrictMode, which doubled the calls. I've removed it in the dApp repo.
- We're making quite a few preflight calls at the start (sometimes as many as 10). I'm still not quite sure why these are happening, or even if they're necessary. 

## How Has This Been Tested?
Locally on my machine.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)