### PR TITLE
Add key based address to user profile details.

### DIFF
--- a/src/components/User/UserProfile.tsx
+++ b/src/components/User/UserProfile.tsx
@@ -22,11 +22,11 @@ import { OPENLOGIN_STORE } from '../../constants/storageConstants';
 import { ENSNode } from 'etherspot';
 
 const UserProfile = () => {
-  const { accountAddress, getEnsNode } = useEtherspot();
+  const { accountAddress, providerAddress, getEnsNode } = useEtherspot();
 
   const theme: Theme = useTheme();
 
-  const [copiedAddress, setCopiedAddress] = useState(false);
+  const [copiedAddress, setCopiedAddress] = useState<{ [key: string]: boolean }>({});
   const [ensName, setEnsName] = useState<string | undefined>(undefined);
 
   let email;
@@ -38,9 +38,9 @@ const UserProfile = () => {
     console.error('Error accessing local storage:', err);
   }
 
-  const onCopySuccess = async () => {
-    setCopiedAddress(true);
-    setTimeout(() => setCopiedAddress(false), 10000);
+  const onCopySuccess = async (address: string) => {
+    setCopiedAddress((prevState) => ({ ...prevState, [address]: true }));
+    setTimeout(() => setCopiedAddress((prevState) => ({ ...prevState, [address]: false })), 10000);
   };
 
   useEffect(() => {
@@ -65,13 +65,39 @@ const UserProfile = () => {
         </Wrapper>
       )}
       <Wrapper>
-        <Header>Address</Header>
+        <Header>Smart wallet address</Header>
         <Value>
           {accountAddress ? (
             <>
               {accountAddress}
-              <Text onClick={() => copyToClipboard(accountAddress, onCopySuccess)} marginLeft={3}>
-                {copiedAddress ? <CheckmarkIcon color={theme.color?.text?.textInput} /> : WalletCopyIcon}
+              <Text onClick={() => copyToClipboard(accountAddress, () => onCopySuccess(accountAddress))} marginLeft={3}>
+                {copiedAddress[accountAddress] ? (
+                  <CheckmarkIcon color={theme.color?.text?.textInput} />
+                ) : (
+                  WalletCopyIcon
+                )}
+              </Text>
+            </>
+          ) : (
+            <p>No address</p>
+          )}
+        </Value>
+      </Wrapper>
+      <Wrapper>
+        <Header>Key based address</Header>
+        <Value>
+          {providerAddress ? (
+            <>
+              {providerAddress}
+              <Text
+                onClick={() => copyToClipboard(providerAddress, () => onCopySuccess(providerAddress))}
+                marginLeft={3}
+              >
+                {copiedAddress[providerAddress] ? (
+                  <CheckmarkIcon color={theme.color?.text?.textInput} />
+                ) : (
+                  WalletCopyIcon
+                )}
               </Text>
             </>
           ) : (

--- a/src/components/User/UserProfile.tsx
+++ b/src/components/User/UserProfile.tsx
@@ -10,11 +10,11 @@ import Card from '../Card';
 import { useEtherspot } from '../../hooks';
 
 // icons
-import { HiCheck } from 'react-icons/hi';
+import { FcCheckmark } from 'react-icons/fc';
 
 // utils
 import { Theme } from '../../utils/theme';
-import { copyToClipboard } from '../../utils/common';
+import { copyToClipboard, humanizeHexString } from '../../utils/common';
 import { CHAIN_ID } from '../../utils/chain';
 
 // constants
@@ -26,7 +26,7 @@ const UserProfile = () => {
 
   const theme: Theme = useTheme();
 
-  const [copiedAddress, setCopiedAddress] = useState<{ [key: string]: boolean }>({});
+  const [copiedAddress, setCopiedAddress] = useState<string>('');
   const [ensName, setEnsName] = useState<string | undefined>(undefined);
 
   let email;
@@ -39,8 +39,8 @@ const UserProfile = () => {
   }
 
   const onCopySuccess = async (address: string) => {
-    setCopiedAddress((prevState) => ({ ...prevState, [address]: true }));
-    setTimeout(() => setCopiedAddress((prevState) => ({ ...prevState, [address]: false })), 10000);
+    setCopiedAddress(address);
+    setTimeout(() => setCopiedAddress(''), 10000);
   };
 
   useEffect(() => {
@@ -68,16 +68,16 @@ const UserProfile = () => {
         <Header>Smart wallet address</Header>
         <Value>
           {accountAddress ? (
-            <>
-              {accountAddress}
+            <AddressCopyButtonWrapper>
+              <AddressWrapper>{humanizeHexString(accountAddress, 36, 4)}</AddressWrapper>
               <Text onClick={() => copyToClipboard(accountAddress, () => onCopySuccess(accountAddress))} marginLeft={3}>
-                {copiedAddress[accountAddress] ? (
+                {copiedAddress == accountAddress ? (
                   <CheckmarkIcon color={theme.color?.text?.textInput} />
                 ) : (
                   WalletCopyIcon
                 )}
               </Text>
-            </>
+            </AddressCopyButtonWrapper>
           ) : (
             <p>No address</p>
           )}
@@ -87,19 +87,19 @@ const UserProfile = () => {
         <Header>Key based address</Header>
         <Value>
           {providerAddress ? (
-            <>
-              {providerAddress}
+            <AddressCopyButtonWrapper>
+              <AddressWrapper>{humanizeHexString(providerAddress, 36, 4)}</AddressWrapper>
               <Text
                 onClick={() => copyToClipboard(providerAddress, () => onCopySuccess(providerAddress))}
                 marginLeft={3}
               >
-                {copiedAddress[providerAddress] ? (
+                {copiedAddress == providerAddress ? (
                   <CheckmarkIcon color={theme.color?.text?.textInput} />
                 ) : (
                   WalletCopyIcon
                 )}
               </Text>
-            </>
+            </AddressCopyButtonWrapper>
           ) : (
             <p>No address</p>
           )}
@@ -136,7 +136,7 @@ const Value = styled.div`
   color: ${({ theme }) => theme.color.text.card};
 `;
 
-const CheckmarkIcon = styled(HiCheck)`
+const CheckmarkIcon = styled(FcCheckmark)`
   margin-top: -3px;
 `;
 
@@ -144,4 +144,14 @@ const HorizontalLine = styled.div`
   width: 100%;
   height: 1px;
   background: ${({ theme }) => theme.color.text.outerLabel};
+`;
+
+const AddressCopyButtonWrapper = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+`;
+
+const AddressWrapper = styled.div`
+  overflow: hidden;
 `;

--- a/src/tests/userProfile.test.tsx
+++ b/src/tests/userProfile.test.tsx
@@ -5,14 +5,16 @@ import UserProfile from '../components/User/UserProfile';
 describe('User Profile component', () => {
   const mockProps = {
     email: 'test@test.com',
-    address: '0x1234567890123456789012345678901234567890',
+    smartWalletAddress: '0x1234567890123456789012345678901234567890',
+    keyBasedAddress: '0x3117e94DE054a002FC552aeF579c982Bd693f609',
     ensNode: 'ensNode.eth',
   };
 
   // Mock useEtherspot hook
   jest.mock('../../hooks', () => ({
     useEtherspot: jest.fn(() => ({
-      accountAddress: mockProps.address,
+      accountAddress: mockProps.smartWalletAddress,
+      providerAddress: mockProps.keyBasedAddress,
       getEnsNode: jest.fn(() => Promise.resolve({ name: mockProps.ensNode })),
     })),
   }));
@@ -35,15 +37,26 @@ describe('User Profile component', () => {
     expect(screen.getByText(mockProps.email)).toBeInTheDocument();
   });
 
-  it('should render user address and copy button', () => {
-    expect(screen.getByText('Address')).toBeInTheDocument();
-    expect(screen.getByText(mockProps.address)).toBeInTheDocument();
+  it('should render smart wallet address and copy button', () => {
+    expect(screen.getByText('Smart wallet address')).toBeInTheDocument();
+    expect(screen.getByText(mockProps.smartWalletAddress)).toBeInTheDocument();
   });
 
-  it('should copy user address to clipboard when copy button is clicked', async () => {
+  it('should render key based address and copy button', () => {
+    expect(screen.getByText('Key based address')).toBeInTheDocument();
+    expect(screen.getByText(mockProps.keyBasedAddress)).toBeInTheDocument();
+  });
+
+  it('should copy key based address to clipboard when copy button is clicked', async () => {
     const copyButton = screen.getByLabelText('Copy address to clipboard');
     fireEvent.click(copyButton);
-    expect(await navigator.clipboard.readText()).toEqual(mockProps.address);
+    expect(await navigator.clipboard.readText()).toEqual(mockProps.keyBasedAddress);
+  });
+
+  it('should copy smart wallet address to clipboard when copy button is clicked', async () => {
+    const copyButton = screen.getByLabelText('Copy address to clipboard');
+    fireEvent.click(copyButton);
+    expect(await navigator.clipboard.readText()).toEqual(mockProps.smartWalletAddress);
   });
 
   it('should render ENS node name', async () => {


### PR DESCRIPTION
Profile Settings Item
## Description
Added user's key based address to the user profile modal along with smart wallet address. 

## Motivation and Context
-  Modal Will display profile information of the user, should it be available.
- Display ENS using a lookup service, should ENS data be available from Etherspot.
- Display smart wallet and keybased address of the user if loged in via metamask/ wallet connect.

## How Has This Been Tested?
- Click on user profile option.
- Display user profile modal.
- Display email if logged in via web3auth/ social login.
- Display smart wallet address/ provider address if logged in via metamask / wallet connet.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/109526304/227861777-60e89ba0-da4b-4468-98e1-5ca9433ab921.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)