### PR TITLE
fix: removed confirmation modals

### DIFF
--- a/src/providers/TransactionBuilderContextProvider.tsx
+++ b/src/providers/TransactionBuilderContextProvider.tsx
@@ -1212,28 +1212,8 @@ const TransactionBuilderContextProvider = ({
                             j === multiCallBlocks.length - 1 && showMulticallOptions !== transactionBlock.id ? 0 : 20
                           }
                           onCloseButtonClick={() =>
-                            showConfirmModal('Are you sure you want to remove selected transaction?', () => {
-                              if (j == 0) {
-                                // Remove entire block if there's only one multicall
-                                setTransactionBlocks((current) => {
-                                  return current.filter((block) => block.id !== transactionBlock.id);
-                                });
-                              } else {
-                                // Remove last instance of a multicall block
-                                setTransactionBlocks((current) => {
-                                  return current
-                                    .filter((block) => block.id !== multiCallBlock.id)
-                                    .map((block) => {
-                                      if (block.id !== multiCallBlock.multiCallData?.lastCallId) {
-                                        return block;
-                                      }
-                                      if (block.multiCallData) {
-                                        block.multiCallData.fixed = false;
-                                      }
-                                      return block;
-                                    });
-                                });
-                              }
+                            setTransactionBlocks((current) => {
+                              return current.filter((block) => block.id !== transactionBlock.id);
                             })
                           }
                           // Should only have the option to delete last multicall, any change mid structure should reset the entire block
@@ -1279,10 +1259,8 @@ const TransactionBuilderContextProvider = ({
                         i === transactionBlocks.length - 1 && showMulticallOptions !== transactionBlock.id ? 0 : 20
                       }
                       onCloseButtonClick={() =>
-                        showConfirmModal('Are you sure you want to remove selected transaction?', () =>
-                          setTransactionBlocks((current) =>
-                            current.filter((addedTransactionBlock) => addedTransactionBlock.id !== transactionBlock.id)
-                          )
+                        setTransactionBlocks((current) =>
+                          current.filter((addedTransactionBlock) => addedTransactionBlock.id !== transactionBlock.id)
                         )
                       }
                       showCloseButton={!editingTransactionBlock}


### PR DESCRIPTION
## Description
Removed existing confirmation modals now on cross button click should remove the block.


## Screenshots (if appropriate):

https://user-images.githubusercontent.com/52369985/229521124-c6665160-f96e-4c73-893b-2bd15926f5bf.mov



## Types of changes
- [x] Breaking change (fix or feature that would cause existing functionality to change)