### PR TITLE
Set min-width for mobile screen [PRO-1353]

### DIFF
--- a/src/containers/Etherspot.tsx
+++ b/src/containers/Etherspot.tsx
@@ -40,7 +40,7 @@ const ComponentWrapper = styled.div`
   box-sizing: content-box;
 
   @media (max-width: 500px) {
-    width: calc(100% - 40px);
+    width: calc(100% - 60px);
     min-width: 350px;
   }
 


### PR DESCRIPTION
## Description
Set min-width for mobile screen

## Motivation and Context
On Buidler, wallet section fits fine on mobile browsers, but other screens are smaller. We need to match size of all screens on BUIDLER(Mobile).

## How Has This Been Tested?
- Local with different mobile device

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/109526304/234023190-d9aab026-a452-408a-b9cc-fa1e4ff42353.png)
![image](https://user-images.githubusercontent.com/109526304/234023320-f3fab6a8-11cc-4079-bebd-a35eff0529ec.png)
![image](https://user-images.githubusercontent.com/109526304/234023376-25d9b11e-75c1-49a1-b021-5d1bfcc68cea.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)