### PR TITLE
Fix: pro 1303 wallet block open on cross button click

### DIFF
--- a/src/providers/TransactionBuilderContextProvider.tsx
+++ b/src/providers/TransactionBuilderContextProvider.tsx
@@ -943,6 +943,16 @@ const TransactionBuilderContextProvider = ({
     openMtPelerinTab(maticSdk, account, deployingAccount, setDeployingAccount, showAlertModal);
   };
 
+  useEffect(() => {
+    if (
+      transactionBlocks?.length === 0 &&
+      crossChainActionsInProcessing?.length !== 0 &&
+      crossChainActions.length !== 0
+    ) {
+      setShowWalletBlock(true);
+    }
+  }, [transactionBlocks, crossChainActionsInProcessing, crossChainActions]);
+
   return (
     <TransactionBuilderContext.Provider value={{ data: contextData }}>
       <TopNavigation>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Now the wallet block will automatically open on in case there's no other block.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] New feature (non-breaking change which adds functionality)