### PR TITLE
PLR Staking BUIDLER: Fix default To selection [PRO-1719]

### DIFF
--- a/src/components/TransactionBlock/PlrStakingV2TransactionBlock.tsx
+++ b/src/components/TransactionBlock/PlrStakingV2TransactionBlock.tsx
@@ -184,29 +184,25 @@ const PlrStakingV2TransactionBlock = ({
   }, [providerAddress, accountAddress, addressPlrBalancePerChain]);
 
   useEffect(() => {
-    const setPlrAsDefault = (selectedAccountType === AccountTypes.Key
-      && providerAddress
-      && addressPlrBalancePerChain?.[providerAddress]?.[CHAIN_ID.ETHEREUM_MAINNET]
-      && isEnoughPlrBalanceToStake(addressPlrBalancePerChain?.[providerAddress]?.[CHAIN_ID.ETHEREUM_MAINNET]))
-    || (selectedAccountType === AccountTypes.Contract
-        && accountAddress
-        && addressPlrBalancePerChain?.[accountAddress]?.[CHAIN_ID.ETHEREUM_MAINNET]
-        && isEnoughPlrBalanceToStake(addressPlrBalancePerChain?.[accountAddress]?.[CHAIN_ID.ETHEREUM_MAINNET]));
-
-    if (!setPlrAsDefault) return;
-
-    const ethereumMainnetChain = supportedChains.find((chain) => chain.chainId === CHAIN_ID.ETHEREUM_MAINNET) as Chain;
-    setSelectedFromNetwork(ethereumMainnetChain);
-    setSelectedToNetwork(ethereumMainnetChain);
+    if (!selectedAccountType || !providerAddress || !accountAddress) return;
 
     const balanceAddress = (selectedAccountType === AccountTypes.Key ? providerAddress : accountAddress) as string;
+
+    const ethereumMainnetChain = supportedChains.find((chain) => chain.chainId === CHAIN_ID.ETHEREUM_MAINNET) as Chain;
     const plrAsset = getPlrAssetForChainId(
       CHAIN_ID.ETHEREUM_MAINNET,
-      addressPlrBalancePerChain[balanceAddress][CHAIN_ID.ETHEREUM_MAINNET] as BigNumber,
+      addressPlrBalancePerChain?.[balanceAddress]?.[CHAIN_ID.ETHEREUM_MAINNET] as BigNumber
     );
 
-    setSelectedFromAsset(plrAsset);
-    setSelectedToAsset(plrStakedAssetEthereumMainnet);
+    if (isEnoughPlrBalanceToStake(addressPlrBalancePerChain?.[providerAddress]?.[CHAIN_ID.ETHEREUM_MAINNET])) {
+      setSelectedFromNetwork(ethereumMainnetChain);
+      setSelectedToNetwork(ethereumMainnetChain);
+      setSelectedFromAsset(plrAsset);
+      setSelectedToAsset(plrStakedAssetEthereumMainnet);
+    } else {
+      setSelectedToNetwork(ethereumMainnetChain);
+      setSelectedToAsset(plrAsset);
+    }
   }, [
     addressPlrBalancePerChain,
     selectedAccountType,
@@ -551,7 +547,7 @@ const PlrStakingV2TransactionBlock = ({
 
   return (
     <>
-    {!hideTitle && <Title>Pillar Validator Staking</Title>}
+      {!hideTitle && <Title>Pillar Validator Staking</Title>}
       <ContainerWrapper>
         <Container>
           <Text size={14}>
@@ -679,6 +675,7 @@ const PlrStakingV2TransactionBlock = ({
         selectedAsset={selectedToAsset}
         errorMessage={errorMessages?.toChain || errorMessages?.toAsset}
         disabled={assetToSelectDisabled}
+        readOnly={assetToSelectDisabled}
         hideChainIds={[CHAIN_ID.AVALANCHE]}
         hideAssets={
           selectedFromNetwork && selectedFromAsset


### PR DESCRIPTION
## Description
- If user does not have enough PLR on Ethereum, the option for them is To is PLR on Ethereum.
- If user has 10k or more PLR on Ethereum (on either wallet), select PLR on Ethereum in From and display stkPLR in To and allow user to input how much PLR on Ethereum they want to stake.

## Screenshots (if appropriate):
Enough PLR
![image](https://github.com/etherspot/etherspot-react-transaction-buidler/assets/109526304/86d40f34-28f1-4a71-910b-83ead2559442)

Not Enough PLR
![image](https://github.com/etherspot/etherspot-react-transaction-buidler/assets/109526304/359b0e69-fd15-40c0-9676-5270997ec422)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)