### PR TITLE
add transaction history on history page

### DIFF
--- a/src/components/History/History.tsx
+++ b/src/components/History/History.tsx
@@ -1,32 +1,116 @@
-import React, {
-  useEffect,
-  useState,
-} from 'react';
+import React, { useEffect, useState } from 'react';
 
-import {
-  getItem,
-} from '../../services/storage';
+import { getItem, setItem } from '../../services/storage';
 import { STORED_GROUPED_CROSS_CHAIN_ACTIONS } from '../../constants/storageConstants';
 import ActionPreview from '../TransactionPreview/ActionPreview';
-import { ICrossChainAction } from '../../types/crossChainAction';
+import { ICrossChainAction, ICrossChainActionTransaction } from '../../types/crossChainAction';
+
+// Hooks
+import { useEtherspot } from '../../hooks';
+
+//utils
+import { fetchTransactionsData } from '../../utils/transaction';
+import { CHAIN_ID } from '../../utils/chain';
+
+//constants
+import { TRANSACTION_BLOCK_TYPE } from '../../constants/transactionBuilderConstants';
+import { CROSS_CHAIN_ACTION_STATUS } from '../../constants/transactionDispatcherConstants';
+
+import { uniqueId } from 'lodash';
 
 const History = () => {
-  const [storedGroupedCrossChainActions, setStoredGroupedCrossChainActions] = useState<{ [id: string]: ICrossChainAction[] }>({})
+  const [storedGroupedCrossChainActions, setStoredGroupedCrossChainActions] = useState<{
+    [id: string]: ICrossChainAction[];
+  }>({});
+  const { getSdkForChainId, accountAddress, sdk } = useEtherspot();
 
   const getLatest = () => {
     try {
-      const storedGroupedCrossChainActionsRaw = getItem(STORED_GROUPED_CROSS_CHAIN_ACTIONS);
-      const storedGroupedCrossChainActionsUpdated = storedGroupedCrossChainActionsRaw
-        ? JSON.parse(storedGroupedCrossChainActionsRaw)
-        : {};
-      setStoredGroupedCrossChainActions(storedGroupedCrossChainActionsUpdated);
+      let storedGroupedCrossChainActionsUpdated;
+      let storedGroupedCrossChainActionsRaw = getItem(STORED_GROUPED_CROSS_CHAIN_ACTIONS);
+      if (storedGroupedCrossChainActionsRaw) {
+        storedGroupedCrossChainActionsUpdated = storedGroupedCrossChainActionsRaw
+          ? JSON.parse(storedGroupedCrossChainActionsRaw)
+          : {};
+        setStoredGroupedCrossChainActions(storedGroupedCrossChainActionsUpdated);
+      } else {
+      }
     } catch (e) {
       //
     }
   };
+  const getTransactionsData = async () => {
+    const sdk = getSdkForChainId(CHAIN_ID.POLYGON);
+    try {
+      if (!sdk) return;
+
+      let results = await fetchTransactionsData(sdk, accountAddress);
+
+      if (results?.items?.length) {
+        results?.items.map((item) => {
+          const chainId = 137;
+          const receiverAddress = item.to;
+          const fromAddress = item.asset.from;
+          const isFromEtherspotWallet = false;
+          const assetUsdPrice = 1;
+          const createTimestamp = +new Date();
+          const crossChainActionId = uniqueId(`${createTimestamp}-`);
+          const transactionId = uniqueId(`${createTimestamp}-`);
+
+          let preview = {
+            chainId,
+            receiverAddress,
+            fromAddress,
+            isFromEtherspotWallet,
+            asset: {
+              address: item.asset.from,
+              decimals: item.asset.decimal,
+              symbol: item.asset.symbol,
+              amount: '1',
+              iconUrl: 'https://polygonscan.com/token/images/klimadao_32.png',
+              usdPrice: assetUsdPrice,
+            },
+          };
+
+          let transferTransaction: ICrossChainActionTransaction = {
+            to: receiverAddress,
+            value: '1',
+            createTimestamp,
+            status: CROSS_CHAIN_ACTION_STATUS.CONFIRMED,
+          };
+
+          let crossChainAction: ICrossChainAction[] = [
+            {
+              id: crossChainActionId,
+              relatedTransactionBlockId: transactionId,
+              chainId: chainId,
+              type: TRANSACTION_BLOCK_TYPE.SEND_ASSET,
+              preview,
+              transactions: [transferTransaction],
+              isEstimating: false,
+              estimated: null,
+              useWeb3Provider: !isFromEtherspotWallet,
+            },
+          ];
+
+          storedGroupedCrossChainActions[crossChainActionId] = [...crossChainAction];
+
+          const storedGroupedCrossChainActionsUpdated = storedGroupedCrossChainActions;
+
+          setItem(STORED_GROUPED_CROSS_CHAIN_ACTIONS, JSON.stringify(storedGroupedCrossChainActionsUpdated));
+        });
+      } else {
+        return { errorMessage: 'No Transactions Found' };
+      }
+    } catch (e) {
+      return { errorMessage: 'Failed to build Transactions' };
+    }
+  };
 
   useEffect(() => {
+    getTransactionsData();
     getLatest();
+
     let intervalId = setInterval(getLatest, 3000);
     return () => {
       if (!intervalId) return;
@@ -35,28 +119,21 @@ const History = () => {
   }, []);
 
   // newest to oldest
-  const storedGroupedCrossChainActionsIds = Object.keys(storedGroupedCrossChainActions)
-    .sort()
-    .reverse();
+  const storedGroupedCrossChainActionsIds = Object.keys(storedGroupedCrossChainActions).sort().reverse();
 
   return (
     <>
-      {!storedGroupedCrossChainActionsIds?.length && (
-        <p>No history.</p>
-      )}
-      {storedGroupedCrossChainActionsIds.map((id) => (
+      {!storedGroupedCrossChainActionsIds?.length && <p>No history.</p>}
+      {storedGroupedCrossChainActionsIds.map((id) =>
         storedGroupedCrossChainActions[id]
           .sort()
           .reverse()
           .map((crossChainAction) => (
-            <ActionPreview
-              key={`action-preview-${id}-${crossChainAction.id}`}
-              crossChainAction={crossChainAction}
-            />
+            <ActionPreview key={`action-preview-${id}-${crossChainAction.id}`} crossChainAction={crossChainAction} />
           ))
-      ))}
+      )}
     </>
-  )
+  );
 };
 
 export default History;

--- a/src/utils/transaction.ts
+++ b/src/utils/transaction.ts
@@ -10,6 +10,7 @@ import {
   TransactionStatuses,
   WalletProviderLike,
   Web3WalletProvider,
+  Account,
 } from 'etherspot';
 import { Route } from '@lifi/sdk';
 import { BigNumber, BigNumberish, ethers, utils } from 'ethers';
@@ -2560,4 +2561,13 @@ export const deployAccount = async (sdk: EtherspotSdk | null) => {
   await sdk.batchDeployAccount();
   await sdk.estimateGatewayBatch();
   return sdk.submitGatewayBatch();
+};
+
+export const fetchTransactionsData = async (sdk: EtherspotSdk | null, accountAddress: String | null) => {
+  if (!sdk) return { errorMessage: 'No sdk found' };
+  //const account = '0x468638F0a6680A8Bb03C4B99dBB160B043c0e9A8';
+  await sdk.computeContractAccount();
+  const results = await sdk.getTransactions({ account: accountAddress as string });
+  console.log(results);
+  return { ...results };
 };


### PR DESCRIPTION
<!--- Add Trasaction History on History page -->

## Description
Write function to get transactions data from sdk and then  put returned data array in crosschainaction array same like stored in cache. but some fields are missing in sdk returned data so, put them static to make some progress on this ticket. Scroll is pending , we need to put scroll to display all transactions.
-

## Motivation and Context
https://linear.app/pillarproject/issue/PRO-1192/transaction-history
-

## How Has This Been Tested?
Testing using one account which has transactions inside it. scroll functionality is pending
Testend on my local machine
changes on History page only.

## Screenshots (if appropriate):
<img width="471" alt="Screenshot 2023-08-23 at 12 35 58 PM" src="https://github.com/etherspot/etherspot-react-transaction-buidler/assets/141008551/7bfaae09-eb83-46c2-a662-1b5d0bc5c5cb">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ Tick] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)