### PR TITLE
PRO-1822 Task: Restrict networks available

### DIFF
--- a/src/utils/chain.ts
+++ b/src/utils/chain.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
 import { BigNumber, ethers } from 'ethers';
 import { TokenListToken } from 'etherspot/dist/sdk/assets/classes/token-list-token';
 import { EnvNames as EtherspotEnvNames } from 'etherspot';
@@ -225,6 +226,33 @@ export const testnetSupportedChains: Chain[] = [
     explorerUrl: 'https://www.oklink.com/okexchain-test/tx/',
   },
 ];
+
+export const primeNativeAssets: { [chainId: number]: TokenListToken } = {
+  [MAINNET_CHAIN_ID.POLYGON]: {
+    chainId: MAINNET_CHAIN_ID.POLYGON,
+    address: ethers.constants.AddressZero,
+    name: 'Matic',
+    symbol: 'MATIC',
+    decimals: 18,
+    logoURI: 'https://public.etherspot.io/buidler/chain_logos/native_tokens/matic.png',
+  },
+  [MAINNET_CHAIN_ID.OPTIMISM]: {
+    chainId: MAINNET_CHAIN_ID.OPTIMISM,
+    address: ethers.constants.AddressZero,
+    name: 'Optimism',
+    symbol: 'ETH',
+    decimals: 18,
+    logoURI: 'https://public.etherspot.io/buidler/chain_logos/ethereum.png',
+  },
+  [MAINNET_CHAIN_ID.ARBITRUM]: {
+    chainId: MAINNET_CHAIN_ID.ARBITRUM,
+    address: ethers.constants.AddressZero,
+    name: 'Arbitrum',
+    symbol: 'ETH',
+    decimals: 18,
+    logoURI: 'https://public.etherspot.io/buidler/chain_logos/ethereum.png',
+  },
+};
 
 export const mainnetNativeAssets: { [chainId: number]: TokenListToken } = {
   [MAINNET_CHAIN_ID.ETHEREUM_MAINNET]: {
@@ -457,8 +485,30 @@ export const testnetNativeAssets: { [chainId: number]: TokenListToken } = {
 };
 
 export let CHAIN_ID = MAINNET_CHAIN_ID;
+const primeSupportedChains = [
+  {
+    chainId: MAINNET_CHAIN_ID.POLYGON,
+    title: 'Polygon',
+    iconUrl: 'https://public.etherspot.io/buidler/chain_logos/polygon.svg',
+    explorerUrl: 'https://polygonscan.com/tx/',
+  },
+  {
+    chainId: MAINNET_CHAIN_ID.ARBITRUM,
+    title: 'Arbitrum',
+    iconUrl: 'https://public.etherspot.io/buidler/chain_logos/arbitrum.svg',
+    explorerUrl: 'https://arbiscan.io/tx/',
+  },
+  {
+    chainId: MAINNET_CHAIN_ID.OPTIMISM,
+    title: 'Optimism',
+    iconUrl: 'https://public.etherspot.io/buidler/chain_logos/optimism.png',
+    explorerUrl: 'https://optimistic.etherscan.io/tx/',
+  },
+];
 export let supportedChains: Chain[] = mainnetSupportedChains;
 export let nativeAssetPerChainId = mainnetNativeAssets;
+export const primeSdkSupportedChains: Chain[] = primeSupportedChains;
+export const primeNativeAssetPerChainId = primeNativeAssets;
 
 export const changeChainId = (value: EtherspotEnvNames) => {
   if (value === EtherspotEnvNames.MainNets) {

--- a/src/utils/theme.ts
+++ b/src/utils/theme.ts
@@ -56,6 +56,7 @@ export interface Theme {
       tooltip?: string;
       tooltipBorder?: string;
       walletDisplayTypeButtonActive?: string;
+      unsupportedNetworksCard?: string;
     };
     text?: {
       main?: string;
@@ -101,6 +102,7 @@ export interface Theme {
       settingsMenuItem?: string;
       settingsMenuItemHover?: string;
       tooltip?: string;
+      warningIcon?: string;
     };
   };
 }
@@ -235,7 +237,7 @@ export const darkTheme: Theme = {
       selectInputScrollbarHover: '#2d2457',
       selectInputScrollbarActive: '#2d2457',
       textInput: '#1a1726',
-      textInputBorder:'#46464e',
+      textInputBorder: '#46464e',
       switchInput: '#1a1726',
       switchInputActiveTab:
         'linear-gradient(to bottom, #734fb3, #422d66), linear-gradient(to bottom, #3d265c, #222130)',
@@ -260,6 +262,7 @@ export const darkTheme: Theme = {
       walletAssetCopyIcon: '#ff9c1b',
       tooltip: '#2f274d',
       tooltipBorder: '#b5afaf',
+      unsupportedNetworksCard: '#3d3767',
     },
     text: {
       selectInput: '#ffeee6',
@@ -300,6 +303,7 @@ export const darkTheme: Theme = {
       settingsMenuItem: '#fff',
       settingsMenuItemHover: '#f4973a',
       tooltip: '#fff',
+      warningIcon: '#F7931A',
     },
   },
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- When a user connects to the BUIDLer via their EOA, performed a check to make sure that the connected network is either:

1. Polygon

2. Arbitrum

3. Optimism

- If a user connects with any other network:

- Displayed an alert message stating that the user must change to either Polygon, Arbitrum, Optimism to continue

- Until the user connects with a supported network, disabled the UI

## Screenshots (if appropriate):
![image](https://github.com/etherspot/etherspot-react-transaction-buidler/assets/141617251/e77d5d37-31d6-4615-a44f-7089da6ea20e)
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)