### PR TITLE
PRO-2112 PLR Staking

### DIFF
--- a/src/components/TransactionBlock/PlrStakingV2TransactionBlock.tsx
+++ b/src/components/TransactionBlock/PlrStakingV2TransactionBlock.tsx
@@ -24,7 +24,7 @@ import { IAssetWithBalance } from '../../providers/EtherspotContextProvider';
 // utils
 import { formatAmountDisplay, formatMaxAmount, formatAssetAmountInput, isEtherspotPrime } from '../../utils/common';
 import { addressesEqual, isValidEthereumAddress, isValidAmount } from '../../utils/validation';
-import { Chain, supportedChains, CHAIN_ID } from '../../utils/chain';
+import { Chain, supportedChains as chains, CHAIN_ID } from '../../utils/chain';
 import { swapServiceIdToDetails } from '../../utils/swap';
 import { Theme } from '../../utils/theme';
 import { bridgeServiceIdToDetails } from '../../utils/bridge';
@@ -152,8 +152,14 @@ const PlrStakingV2TransactionBlock = ({
   errorMessages,
   values,
   hideTitle = false,
+  onlyPolygonInPLRStaking = false,
 }: IPlrStakingV2Block) => {
   const { sdk, providerAddress, accountAddress, smartWalletOnly, etherspotMode } = useEtherspot();
+
+  const supportedChains = chains.filter(({ chainId }) => (onlyPolygonInPLRStaking ? chainId === 137 : true));
+  const hideChainIds = chains
+    .filter(({ chainId }) => (onlyPolygonInPLRStaking ? chainId !== 137 : chainId === 43114))
+    .map(({ chainId }) => chainId);
 
   const [amount, setAmount] = useState<string>(values?.amount ?? '');
   const [selectedAccountType, setSelectedAccountType] = useState<string>(values?.accountType ?? AccountTypes.Contract);
@@ -712,7 +718,7 @@ const PlrStakingV2TransactionBlock = ({
         selectedAsset={selectedFromAsset}
         errorMessage={errorMessages?.fromChain || errorMessages?.fromAsset}
         walletAddress={selectedAccountType === AccountTypes.Contract ? accountAddress : providerAddress}
-        hideChainIds={[CHAIN_ID.AVALANCHE]}
+        hideChainIds={hideChainIds}
         showPositiveBalanceAssets
         showQuickInputButtons
         accountType={selectedAccountType}

--- a/src/containers/Etherspot.tsx
+++ b/src/containers/Etherspot.tsx
@@ -44,6 +44,7 @@ interface EtherspotProps {
   hideActionPreviewHeader?: boolean;
   walletBlockActionsReplaceBehaviour?: boolean;
   etherspotMode?: 'etherspot' | 'etherspot-prime';
+  onlyPolygonInPLRStaking?: boolean;
 }
 
 const ComponentWrapper = styled.div.attrs(
@@ -109,6 +110,7 @@ const Etherspot = ({
   walletBlockActionsReplaceBehaviour = false,
   onLogout,
   etherspotMode = ETHERSPOT,
+  onlyPolygonInPLRStaking = false,
 }: EtherspotProps) => {
   const [activeTheme, setActiveTheme] = useState(getTheme(ThemeType.DARK));
 
@@ -161,6 +163,7 @@ const Etherspot = ({
                   hideTransactionBlockTitle={hideTransactionBlockTitle}
                   hideWalletSwitch={hideWalletSwitch}
                   hideActionPreviewHeader={hideActionPreviewHeader}
+                  onlyPolygonInPLRStaking={onlyPolygonInPLRStaking}
                 />
               </TransactionsDispatcherContextProvider>
             </TransactionBuilderModalContextProvider>

--- a/src/providers/TransactionBuilderContextProvider.tsx
+++ b/src/providers/TransactionBuilderContextProvider.tsx
@@ -84,6 +84,7 @@ export interface TransactionBuilderContextProps {
   hideWalletSwitch?: boolean;
   hideActionPreviewHeader?: boolean;
   walletBlockActionsReplaceBehaviour?: boolean;
+  onlyPolygonInPLRStaking?: boolean;
 }
 
 export interface IMulticallBlock {
@@ -423,6 +424,7 @@ const TransactionBuilderContextProvider = ({
   hideWalletSwitch = false,
   hideActionPreviewHeader = false,
   walletBlockActionsReplaceBehaviour = false,
+  onlyPolygonInPLRStaking = false,
 }: TransactionBuilderContextProps) => {
   const context = useContext(TransactionBuilderContext);
 
@@ -1017,7 +1019,7 @@ const TransactionBuilderContextProvider = ({
       );
       return;
     }
-    if (availableTransactionBlock.type === TRANSACTION_BLOCK_TYPE.DISABLED || isBridgeTransactionBlockAndDisabled){
+    if (availableTransactionBlock.type === TRANSACTION_BLOCK_TYPE.DISABLED || isBridgeTransactionBlockAndDisabled) {
       return;
     }
     const transactionBlock: ITransactionBlock = {
@@ -1498,6 +1500,7 @@ const TransactionBuilderContextProvider = ({
                               errorMessages={transactionBlockValidationErrors[transactionBlock.id]}
                               hideTitle={hideTransactionBlockTitle}
                               hideWalletSwitch={hideWalletSwitch}
+                              onlyPolygonInPLRStaking={onlyPolygonInPLRStaking}
                             />
                             {j === multiCallBlocks.length - 1 &&
                               multiCallBlock.type == TRANSACTION_BLOCK_TYPE.ASSET_SWAP && (
@@ -1531,7 +1534,11 @@ const TransactionBuilderContextProvider = ({
                             current.filter((addedTransactionBlock) => addedTransactionBlock.id !== transactionBlock.id)
                           )
                         }
-                        showCloseButton={!hideCloseTransactionBlockButton && !editingTransactionBlock && (transactionBlock.closeable ?? true)}
+                        showCloseButton={
+                          !hideCloseTransactionBlockButton &&
+                          !editingTransactionBlock &&
+                          (transactionBlock.closeable ?? true)
+                        }
                         removeContainer={removeTransactionBlockContainer}
                       >
                         <TransactionBlock
@@ -1540,6 +1547,7 @@ const TransactionBuilderContextProvider = ({
                           errorMessages={transactionBlockValidationErrors[transactionBlock.id]}
                           hideTitle={hideTransactionBlockTitle}
                           hideWalletSwitch={hideWalletSwitch}
+                          onlyPolygonInPLRStaking={onlyPolygonInPLRStaking}
                         />
                         {transactionBlock.type === TRANSACTION_BLOCK_TYPE.ASSET_SWAP &&
                           transactionBlock.values?.accountType === DestinationWalletEnum.Contract &&

--- a/src/types/transactionBlock.ts
+++ b/src/types/transactionBlock.ts
@@ -29,6 +29,7 @@ export type ITransactionBlockBase = {
   multiCallData?: IMultiCallData | null;
   hideTitle?: boolean;
   hideWalletSwitch?: boolean;
+  onlyPolygonInPLRStaking?: boolean;
 };
 
 export type ITransactionBlockType =


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
https://linear.app/pillarproject/issue/PRO-2112/plr-staking

## Description
<!--- Describe your changes in detail -->
- Added `onlyPolygonInPLRStaking` prop. used for lock polygon in PLR staking.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
-

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Tested on local

## Screenshots (if appropriate):

https://github.com/etherspot/etherspot-react-transaction-buidler/assets/82652040/31d9d973-d77e-418d-95be-f821e5c1849e



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)